### PR TITLE
Use special property from python-telegram-bot, instead self-written solution

### DIFF
--- a/tgbot/handlers/utils/info.py
+++ b/tgbot/handlers/utils/info.py
@@ -17,18 +17,7 @@ def send_typing_action(func: Callable):
 
 def extract_user_data_from_update(update: Update) -> Dict:
     """ python-telegram-bot's Update instance --> User info """
-    if update.message is not None:
-        user = update.message.from_user.to_dict()
-    elif update.inline_query is not None:
-        user = update.inline_query.from_user.to_dict()
-    elif update.chosen_inline_result is not None:
-        user = update.chosen_inline_result.from_user.to_dict()
-    elif update.callback_query is not None and update.callback_query.from_user is not None:
-        user = update.callback_query.from_user.to_dict()
-    elif update.callback_query is not None and update.callback_query.message is not None:
-        user = update.callback_query.message.chat.to_dict()
-    else:
-        raise Exception(f"Can't extract user data from update: {update}")
+    user = update.effective_user.to_dict()
 
     return dict(
         user_id=user["id"],


### PR DESCRIPTION
The property [update.effective_user](https://github.com/python-telegram-bot/python-telegram-bot/blob/2c84122654b1ffff6e671b7f50b035023a6d5c6b/telegram/_update.py#L266) does exactly the same, as original if/elif codeblock in `extract_user_data_from_update`

It covers more cases, no exceptions, and less code in the repo. Profit!

I've checked locally that the user created without any problems:

<img width="1329" alt="Screen Shot 2022-08-15 at 11 14 08" src="https://user-images.githubusercontent.com/5013076/184602644-21e8aa35-54cf-4fda-9564-eef34e95fffc.png">

