### PR TITLE
Updated restart policy to match the Database container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   web:
     build: .
     container_name: dtb_django
+    restart: always
     command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/code
@@ -32,6 +33,7 @@ services:
   bot:
     build: .
     container_name: dtb_bot
+    restart: always
     command: python run_polling.py
     env_file:
       - ./.env
@@ -40,6 +42,7 @@ services:
   celery:
     build: .
     container_name: dtb_celery
+    restart: always
     command: celery -A dtb worker --loglevel=INFO
     volumes:
       - .:/code
@@ -51,6 +54,7 @@ services:
   celery-beat:
     build: .
     container_name: dtb_beat
+    restart: always
     command: celery -A dtb beat -l info --scheduler django_celery_beat.schedulers.DatabaseScheduler
     volumes:
       - .:/code


### PR DESCRIPTION
Currently only the database container restart policy is set to restart always.

I imagine it should be consistent across containers described in `docker-compose.yml` (since we assume that one doesn't use the postgres database which is already used by django for something else), so set all of the containers' restart policies to be `restart: always`.