### PR TITLE
psycopg2 update & DEFAULT_AUTO_FIELD added

### DIFF
--- a/dtb/settings.py
+++ b/dtb/settings.py
@@ -68,6 +68,8 @@ INTERNAL_IPS = [
     # ...
 ]
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
 
@@ -180,4 +182,3 @@ TELEGRAM_LOGS_CHAT_ID = os.getenv("TELEGRAM_LOGS_CHAT_ID", default=None)
 #     # django.contrib.auth) you may enable sending PII data.
 #     send_default_pii=True
 # )
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gunicorn==20.1.0
 uvicorn==0.18.3
 
 # Databases
-psycopg2-binary==2.9.3
+psycopg2-binary==2.9.9
 dj-database-url==1.0.0
 
 # Distributed async tasks


### PR DESCRIPTION
1. I was facing _"pg_config executable not found."_ error when doing `pip install -r requirement.txt`. seems like package update will fix the problem.
2. `DEFAULT_AUTO_FIELD` added to settings.py to remove the warning while migrating.
